### PR TITLE
Require pub 1.5

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,3 @@
-required.packages=managed
+required.packages=pub,managed
+version.pub=1.5
 version.managed=Not Installed


### PR DESCRIPTION
Just a note, this is not included in release notes
# Warning
- This package now requires at least version 1.5 of the "pub" managed package
# Info
- You can automatically install the "pub" package by running ant updateRequiredPackages
# Issues
