### PR TITLE
Updating Solano CI setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+simple-salesforce
+selenium
+requests
+PyGithub==1.25.1

--- a/solano.yml
+++ b/solano.yml
@@ -1,22 +1,30 @@
 # Use Python 2.7 for scripts
 python:
   python_version: 2.7
+  pip_requirements_file: requirements.txt
 
 hooks:
-  worker_setup: 'solano/setup.sh'
+  pre_setup: |
+    set -e # Exit on error
+    git clone https://github.com/SalesforceFoundation/CumulusCI CumulusCI
+    cd CumulusCI
+    git fetch --all
+    git checkout features/cloud-ci-integrations
+    mkdir apex_debug_logs
 
 environment:
-  CUMULUSCI_PATH: /tmp/CumulusCI
+  CUMULUSCI_PATH: CumulusCI
   TEST_MODE: parallel
   DEBUG_TESTS: true
   DEBUG_LOGDIR: apex_debug_logs
   TEST_JSON_OUTPUT: test_results.json
   TEST_JUNIT_OUTPUT: test_results_junit.xml
 
-test_pattern: 'none'
+test_pattern: 
+  - 'none'
+
 tests:
-  - type: custom
-    command: 'unbuffer $CUMULUSCI_PATH/ci/ant_wrapper.sh deployCI'
+  - ./CumulusCI/ci/ant_wrapper.sh deployCI
 
 collect:
   repo:

--- a/solano/setup.sh
+++ b/solano/setup.sh
@@ -1,9 +1,0 @@
-BASEDIR=`pwd`
-cd /tmp
-git clone https://github.com/SalesforceFoundation/CumulusCI
-cd CumulusCI
-git fetch --all
-git checkout features/cloud-ci-integrations
-$CUMULUSCI_PATH/ci/cloud/solano/setup.sh
-cd $BASEDIR
-mkdir apex_debug_logs


### PR DESCRIPTION
This negates the need to execute https://github.com/SalesforceFoundation/CumulusCI/blob/features/cloud-ci-integrations/ci/cloud/solano/setup.sh (or for it to even exist). I was wondering why this repo cloned CumulusCI, and then called that script, which appears to do the same cloning and branch setting.

I've also added a requirements.txt file and pointed Solano's automatic pip installer to use it.

While it isn't a problem with single-test builds, we discourage the use of /tmp since if multiple workers are on the same file system the files within /tmp may corrupt. We recommend using the $TMPDIR environment variable instead, but in this case I didn't see why you weren't just using the repo's root directory.

And speaking of multiple workers, for file system based dependencies, we recommend using the `pre_setup` hook. The `worker_setup` hook is typically only used for worker-specific update tasks like setting up per-worker databases, setting up Elasticsearch, etc.

While I did a build with my fork, it failed due to not having the required environment variables set. 

-Isaac